### PR TITLE
Don't check groups/bulbs/scenes that have null data.

### DIFF
--- a/smartapps/info-fiend/hue-b-smart.src/hue-b-smart.groovy
+++ b/smartapps/info-fiend/hue-b-smart.src/hue-b-smart.groovy
@@ -1233,22 +1233,24 @@ def itemDiscoveryHandler(evt) {
    	            def groupId = it.deviceNetworkId.split("/")[1] - "GROUP"
            	    def g = bridge.value.groups[groupId]
 				def groupFromBridge = bridge.value.groups[groupId]
+                if ( groupFromBridge != null ) {
+                    
+                    def gLights = groupFromBridge.lights
+                    def test
                 
-                def gLights = groupFromBridge.lights
-                def test
+                    def colormode = bridge.value.groups[groupId]?.action?.colormode
+                    if (colormode != null) {
                 
-                def colormode = bridge.value.groups[groupId]?.action?.colormode
-                if (colormode != null) {
-                
-					["on", "bri", "sat", "ct", "xy", "effect", "hue", "colormode"].each { p -> 
-       	            	test = bridge.value.groups[groupId].action[p]
-                   	    it.updateStatus("action", p, bridge.value.groups[groupId].action[p])                        
-        			}
-				}else{
-					 ["bri", "on"].each { p ->
-                        it.updateStatus("action", p, bridge.value.groups[groupId].action[p])
-                      }
-				}
+    					["on", "bri", "sat", "ct", "xy", "effect", "hue", "colormode"].each { p -> 
+           	            	test = bridge.value.groups[groupId].action[p]
+                       	    it.updateStatus("action", p, bridge.value.groups[groupId].action[p])                        
+        	    		}
+			    	}else{
+				    	 ["bri", "on"].each { p ->
+                            it.updateStatus("action", p, bridge.value.groups[groupId].action[p])
+                         }
+				    }
+                }
             }
             
             if (it.deviceNetworkId.contains("SCENE")) {

--- a/smartapps/info-fiend/hue-b-smart.src/hue-b-smart.groovy
+++ b/smartapps/info-fiend/hue-b-smart.src/hue-b-smart.groovy
@@ -1211,39 +1211,39 @@ def itemDiscoveryHandler(evt) {
     		if (it.deviceNetworkId.contains("BULB")) {
 	            log.trace "contains BULB / DNI = ${it.deviceNetworkId}: ${it}"
    	            def bulbId = it.deviceNetworkId.split("/")[1] - "BULB"
-       	        log.debug "bulbId = ${bulbId}" 
+       	        log.debug "bulbId = ${bulbId}"
                 def bBulb = bridge.value.bulbs[bulbId]
                 log.debug "bridge.value.bulbs[bulbId] = ${bBulb}."
-				def type = bBulb.type 	// bridge.value.bulbs[bulbId].type
-               	if (type.equalsIgnoreCase("Dimmable light")) {
-					["reachable", "on", "bri"].each { p -> 
-   	                	it.updateStatus("state", p, bridge.value.bulbs[bulbId].state[p])
-					}
-           	    } else if (type.equalsIgnoreCase("Color Temperature Light")) {
-					["bri", "ct", "reachable", "on"].each { p ->
-                       	it.updateStatus("state", p, bridge.value.bulbs[bulbId].state[p])
-    				}
-			    } else {
-					["reachable", "on", "bri", "hue", "sat", "ct", "xy","effect", "colormode"].each { p -> 
-                   		it.updateStatus("state", p, bridge.value.bulbs[bulbId].state[p])                        
-					}
-   	            }
+                if ( bBulb != null ) {  // If user removes bulb from hue without removing it from smartthings,
+                                        // getChildDevices() will still return the scene as part of the array as null, so we need to check for it to prevent crashing.
+				    def type = bBulb.type 	// bridge.value.bulbs[bulbId].type
+               	    if (type.equalsIgnoreCase("Dimmable light")) {
+					    ["reachable", "on", "bri"].each { p -> 
+   	                	    it.updateStatus("state", p, bridge.value.bulbs[bulbId].state[p])
+					    }
+           	        } else if (type.equalsIgnoreCase("Color Temperature Light")) {
+					    ["bri", "ct", "reachable", "on"].each { p ->
+                       	    it.updateStatus("state", p, bridge.value.bulbs[bulbId].state[p])
+    				    }
+			        } else {
+					    ["reachable", "on", "bri", "hue", "sat", "ct", "xy","effect", "colormode"].each { p -> 
+                   		    it.updateStatus("state", p, bridge.value.bulbs[bulbId].state[p])
+					    }
+   	                }
+                }
             }
             if (it.deviceNetworkId.contains("GROUP")) {
    	            def groupId = it.deviceNetworkId.split("/")[1] - "GROUP"
            	    def g = bridge.value.groups[groupId]
 				def groupFromBridge = bridge.value.groups[groupId]
-                if ( groupFromBridge != null ) {
-                    
-                    def gLights = groupFromBridge.lights
+                if ( groupFromBridge != null ) {        // If user removes group from hue without removing it from smartthings, 
+                    def gLights = groupFromBridge.lights// getChildDevices() will still return the scene as part of the array as null, so we need to check for it to prevent crashing.
                     def test
-                
                     def colormode = bridge.value.groups[groupId]?.action?.colormode
                     if (colormode != null) {
-                
     					["on", "bri", "sat", "ct", "xy", "effect", "hue", "colormode"].each { p -> 
            	            	test = bridge.value.groups[groupId].action[p]
-                       	    it.updateStatus("action", p, bridge.value.groups[groupId].action[p])                        
+                       	    it.updateStatus("action", p, bridge.value.groups[groupId].action[p])
         	    		}
 			    	}else{
 				    	 ["bri", "on"].each { p ->
@@ -1252,31 +1252,33 @@ def itemDiscoveryHandler(evt) {
 				    }
                 }
             }
-            
+
             if (it.deviceNetworkId.contains("SCENE")) {
             	log.trace "it.deviceNetworkId contains SCENE = ${it.deviceNetworkId}"
-
 				log.trace "contains SCENE / DNI = ${it.deviceNetworkId}"
     	        def sceneId = it.deviceNetworkId.split("/")[1] - "SCENE"
-        	    log.debug "sceneId = ${sceneId}"     
+        	    log.debug "sceneId = ${sceneId}"
                 def sceneFromBridge = bridge.value.scenes[sceneId]
                 log.trace "sceneFromBridge = ${sceneFromBridge}"
-                def sceneLights = []
-                sceneLights = sceneFromBridge.lights
-                def scenelightStates = sceneFromBridge.lightStates
-	            log.trace "bridge.value.scenes[${sceneId}].lights = ${sceneLights}"                    
-				log.trace "bridge.value.scenes[${sceneId}].lightStates = ${scenelightStates}"                    
+                if ( sceneFromBridge != null ) { // If user removes scene from hue without removing it from smartthings,
+                    def sceneLights = []         // getChildDevices() will still return the scene as part of the array as null, so we need to check for it to prevent crashing.
+                    sceneLights = sceneFromBridge.lights
+                    def scenelightStates = sceneFromBridge.lightStates
 
-            	if (bridge.value.scenes[sceneId].lights) {	
-					it.updateStatus("scene", "lights", bridge.value.scenes[sceneId].lights)
-                }
-                if (scenelightStates) {	
-					it.updateStatus("scene", "lightStates", scenelightStates)
-				//	it.updateStatus("scene", "schedule", "off")                    
-                }
-        	}
-		}   		 	
-	}
+	                log.trace "bridge.value.scenes[${sceneId}].lights = ${sceneLights}"
+				    log.trace "bridge.value.scenes[${sceneId}].lightStates = ${scenelightStates}"
+
+            	    if (bridge.value.scenes[sceneId].lights) {
+					    it.updateStatus("scene", "lights", bridge.value.scenes[sceneId].lights)
+                    }
+                    if (scenelightStates) {
+					    it.updateStatus("scene", "lightStates", scenelightStates)
+				//	it.updateStatus("scene", "schedule", "off")
+                    }
+        	    }
+		    }
+	    }
+    }
 }
 
 def locationHandler(evt) {


### PR DESCRIPTION
getChildDevices() returns groups that have been deleted from Hue, but not yet from smartthings. I forgot that I deleted a group that I had on smartthings and it was driving me crazy because I couldn't refresh hue b smart, as it kept loggings errors about how light group 15 returned null data, even though GET groups was only returning up to group 14, as I had deleted group 15 from hue. 

This just checks for null data and skips that group if necessary. It might be nice to add something like "Hey idiot you might need to delete that light group from smartthings since it doesn't work anyway." :) 